### PR TITLE
Null user error partially rectified

### DIFF
--- a/src/middleware/hospitalAuth.js
+++ b/src/middleware/hospitalAuth.js
@@ -21,6 +21,7 @@ const requireAuth = (req, res, next) => {
                 if (hospital == null)
                 {
                     req.flash("error_msg", "You do not have an account yet, kindly sign up for one"); 
+                    res.clearCookie('hospital');
                     res.redirect("/hospital/signup"); 
                     return; 
                 }

--- a/src/middleware/hospitalAuth.js
+++ b/src/middleware/hospitalAuth.js
@@ -17,6 +17,13 @@ const requireAuth = (req, res, next) => {
                 res.redirect('/hospital/login')
             } else {
                 let hospital = await Hospital.findById(decodedToken.id)
+                
+                if (hospital == null)
+                {
+                    req.flash("error_msg", "You do not have an account yet, kindly sign up for one"); 
+                    res.redirect("/hospital/signup"); 
+                    return; 
+                }
 
                 req.hospital = hospital
                 //console.log("current user", req.user)

--- a/src/middleware/userAuth.js
+++ b/src/middleware/userAuth.js
@@ -20,6 +20,7 @@ const requireAuth = (req, res, next) => {
                 if (user == null)
                 {
                     req.flash("error_msg", "You do not have an account yet, kindly sign up for one"); 
+                    res.clearCookie('jwt')
                     res.redirect("/user/signup"); 
                     return; 
                 }

--- a/src/middleware/userAuth.js
+++ b/src/middleware/userAuth.js
@@ -16,7 +16,14 @@ const requireAuth = (req, res, next) => {
                 res.redirect('/user/login')
             } else {
                 let user = await User.findById(decodedToken.id)
-
+                // if null then redirect to signup
+                if (user == null)
+                {
+                    req.flash("error_msg", "You do not have an account yet, kindly sign up for one"); 
+                    res.redirect("/user/signup"); 
+                    return; 
+                }
+                //else to profile
                 req.user = user
                 //console.log("current user", req.user)
 


### PR DESCRIPTION
In case if req.user is null but JWT still exists in browser, the cookie is cleared from the browser and the user is let to the signup page for registration. 

This has been done for both patient and hospital sides. 
